### PR TITLE
fix: Update enginegame.js to use the correct path for stockfish.js in the worker initialization.

### DIFF
--- a/examples/enginegame.js
+++ b/examples/enginegame.js
@@ -3,8 +3,8 @@ function engineGame(options) {
     var game = new Chess();
     var board;
     ///NOTE: If the WASM binary is not in the expected location, must be added after the hash.
-    var engine = typeof STOCKFISH === "function" ? STOCKFISH() : new Worker(options.stockfishjs || 'src/stockfish.js');
-    var evaler = typeof STOCKFISH === "function" ? STOCKFISH() : new Worker(options.stockfishjs || 'src/stockfish.js');
+    var engine = typeof STOCKFISH === "function" ? STOCKFISH() : new Worker(options.stockfishjs || 'node_modules/stockfish/bin/stockfish.js');
+    var evaler = typeof STOCKFISH === "function" ? STOCKFISH() : new Worker(options.stockfishjs || 'node_modules/stockfish/bin/stockfish.js');
     var engineStatus = {};
     var displayScore = false;
     var time = { wtime: 300000, btime: 300000, winc: 2000, binc: 2000 };


### PR DESCRIPTION
### Fix: Correct fallback Stockfish engine path

The example hangs indefinitely while loading the engine because the fallback path is incorrect.

It currently points to:

`src/stockfish.js`

However, `stockfish.js` actually lives at:

`node_modules/stockfish/bin/stockfish.js`

Updating the path fixed the issue for me, and the example ran as expected.

I’ve also seen other issues reporting a similar loading problem (linked below), which this may resolve.

https://github.com/nmrugg/stockfish.js/issues/105
https://github.com/nmrugg/stockfish.js/issues/12