### PR TITLE
docs: add section for stockfishts 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ To learn how to use the engine in your own projects, see the <a href="https://gi
 
 ### How do I use stockfish.js in React.js or in web applications?
 
-You can explore (@jalpp/stockfishts library)[https://www.npmjs.com/package/@jalpp/stockfishts], it is a TypeScript library for running Stockfish engines from both frontend and backend projects. It supports WebAssembly-based engines, worker-based execution, and a small, ergonomic API for evaluating chess positions and receiving incremental updates from stockfish.js wasm engine files. 
+You can explore [@jalpp/stockfishts library](https://www.npmjs.com/package/@jalpp/stockfishts), it is a TypeScript library for running Stockfish engines from both frontend and backend projects. It supports WebAssembly-based engines, worker-based execution, and a small, ergonomic API for evaluating chess positions and receiving incremental updates from stockfish.js wasm engine files. 
 
 ### How do I compile the engine?
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Stockfish.js is simply a raw engine. You'll need to bring the rest of the parts 
 
 To learn how to use the engine in your own projects, see the <a href="https://github.com/nmrugg/stockfish.js/tree/master/examples">examples folder</a>. In particular, see `examples/loadEngine.js` for a sample implementation of how to load and run engines.
 
+### How do I use stockfish.js in React.js or in web applications?
+
+You can explore (@jalpp/stockfishts library)[https://www.npmjs.com/package/@jalpp/stockfishts], it is a TypeScript library for running Stockfish engines from both frontend and backend projects. It supports WebAssembly-based engines, worker-based execution, and a small, ergonomic API for evaluating chess positions and receiving incremental updates from stockfish.js wasm engine files. 
+
 ### How do I compile the engine?
 
 You only need to compile the engine if you want to make changes to the engine itself.


### PR DESCRIPTION
I wrote a library wrapper that takes Stockfish.js files and exposes a runnable Stockfish WASM engine in both frontend/backend projects using the stockfish.js files

see https://www.npmjs.com/package/@jalpp/stockfishts 

Many devs will benefit from this, so I thought to update the readme regarding it