### PR TITLE
Avoid mutating global fetch in Node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "license": "GPL-3.0",
   "bin": "scripts/cli.js",
   "scripts": {
+    "test": "node tests/node-global-fetch.test.js",
     "build": "node build.js -f",
     "build-lite": "node build.js --lite -f",
     "build-single": "node build.js --single-threaded -f",

--- a/src/emscripten/pre.js
+++ b/src/emscripten/pre.js
@@ -1,38 +1,28 @@
 
-/// Fix fetch in Node.js
-if (typeof global !== "undefined" && Object.prototype.toString.call(global.process) === "[object process]" && typeof fetch !== "undefined") {
-    /// XMLHttpRequest polyfill for Node.js.
-    if (typeof XMLHttpRequest === "undefined") {
-        global["XMLHttpRequest"] = function (a)
-        {
-            var url
-            var xhr = {
-                open: function (method, _url)
-                {
-                    url = _url;
-                },
-                send: function ()
-                {
-                    require("fs").readFile(url, function (err, data)
-                    {
-                        xhr.readyState = 4; /// DONE
-                        if (err) {
-                            console.error(err);
-                            xhr.status = 404;
-                            xhr.onerror(err);
-                        } else {
-                            xhr.status = 200;
-                            xhr.response = data;
-                            xhr.onreadystatechange();
-                            xhr.onload();
-                        }
-                    });
-                }
-            };
-            return xhr;
+/// Node 18+ exposes fetch(), but Emscripten 3.1.7 may try to use it with a
+/// local filesystem path. Provide the local binary without changing globals.
+if (typeof process === "object" &&
+        process !== null &&
+        typeof process.versions === "object" &&
+        process.versions !== null &&
+        typeof process.versions.node === "string" &&
+        typeof require === "function" &&
+        typeof fetch === "function" &&
+        typeof Module["wasmBinary"] === "undefined" &&
+        typeof __filename === "string") {
+    (function loadNodeWasmBinary()
+    {
+        var fs = require("fs");
+        var path = require("path");
+        var wasmName = path.basename(__filename, path.extname(__filename)) + ".wasm";
+        var wasmPath = Module["locateFile"] ?
+            Module["locateFile"](wasmName, path.dirname(__filename) + path.sep) :
+            path.join(path.dirname(__filename), wasmName);
+
+        if (typeof wasmPath === "string" && fs.existsSync(wasmPath)) {
+            Module["wasmBinary"] = fs.readFileSync(wasmPath);
         }
-    }
-    fetch = null;
+    }());
 }
 
 Module["print"] = function (data)

--- a/tests/node-global-fetch.test.js
+++ b/tests/node-global-fetch.test.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+
+"use strict";
+
+var assert = require("assert");
+var fs = require("fs");
+var os = require("os");
+var path = require("path");
+var vm = require("vm");
+
+var preJs = fs.readFileSync(path.join(__dirname, "..", "src", "emscripten", "pre.js"), "utf8");
+var tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "stockfish-node-fetch-"));
+var enginePath = path.join(tempDir, "stockfish-test.js");
+var wasmPath = path.join(tempDir, "stockfish-test.wasm");
+var wasmBinary = Buffer.from([0, 97, 115, 109]);
+var splitWasmBinary = Buffer.from([1, 2, 3, 4]);
+var originalFetch = function () {};
+var locatedWasmName;
+var sandbox = {
+    Buffer: Buffer,
+    Module: {
+        locateFile: function (name)
+        {
+            locatedWasmName = name;
+            return wasmPath;
+        }
+    },
+    __filename: enginePath,
+    console: console,
+    fetch: originalFetch,
+    process: process,
+    require: require
+};
+
+fs.writeFileSync(wasmPath, wasmBinary);
+
+try {
+    vm.runInNewContext(preJs, sandbox, {filename: "pre.js"});
+
+    assert.strictEqual(sandbox.fetch, originalFetch, "global fetch must not be replaced");
+    assert.strictEqual(Object.prototype.hasOwnProperty.call(sandbox, "XMLHttpRequest"), false,
+        "initialization must not install global XMLHttpRequest");
+    assert.strictEqual(locatedWasmName, "stockfish-test.wasm");
+    assert.deepStrictEqual(Buffer.from(sandbox.Module.wasmBinary), wasmBinary,
+        "the adjacent WebAssembly binary should be provided to Emscripten");
+
+    sandbox = {
+        Module: {wasmBinary: splitWasmBinary},
+        __filename: enginePath,
+        console: console,
+        fetch: originalFetch,
+        process: process,
+        require: require
+    };
+    vm.runInNewContext(preJs, sandbox, {filename: "pre.js"});
+
+    assert.strictEqual(sandbox.fetch, originalFetch);
+    assert.strictEqual(sandbox.Module.wasmBinary, splitWasmBinary,
+        "a WebAssembly binary assembled from split parts must be preserved");
+} finally {
+    fs.rmSync(tempDir, {recursive: true, force: true});
+}
+
+console.log("Node global fetch regression test passed.");


### PR DESCRIPTION
## Summary

- preserve Node's native global `fetch`
- load the local WebAssembly binary without installing global shims
- preserve a preassembled `wasmBinary`
- add a regression test

## Testing

- `npm test` on Node.js 20.9.0
- exact `initEngine("lite-single")` reproduction from #119
- Emscripten 3.1.7 lite single-threaded and multithreaded builds on Node.js 18.19.1
- real engine initialization, native `fetch()`, and UCI searches for both builds

Closes #119