### PR TITLE
Avoid recursive stream error handling

### DIFF
--- a/src/emscripten/extern-post.js
+++ b/src/emscripten/extern-post.js
@@ -479,7 +479,7 @@ if (typeof self !== "undefined" && self.location.hash.split(",")[1] === "worker"
                                                 onProgress(startTime, loadedBytes, totalBytes);
                                                 controller.enqueue(value);
                                                 push();
-                                            }).catch(function onError(err)
+                                            }).catch(function onReadError(err)
                                             {
                                                 controller.error(err);
                                                 if (typeof onError === "function") {


### PR DESCRIPTION
## Summary

- avoid recursively invoking the stream read error handler
- forward the original read error to the optional callback

## Testing

- deterministic stream read failure reproduction
- reproducible Emscripten 3.1.7 lite-single build
- fixed-node validation across six positions

Closes #120